### PR TITLE
feat: add multi-suite queue for running suites sequentially

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## Release notes
 
+**v6.5.0 (Beta): Multi-suite support - run multiple suites sequentially with `-S suite1,suite2` or all discovered suites with `-A`/`--all-suites`.**
+
 **v6.2.1: To avoid conflicts when running multiple projects in parallel, the docker image name will now be determined in the following order: configurable in the [module configuration](#optional-configuration) ("dockerImageName"), else the name attribute of the package.json file in the project, else finally the directory name.**
 
 **History of previously run tests are stored in local storage, and introducing X-ray mode in 6.1.0!**
@@ -545,6 +547,12 @@ Flags just allow you to skip the UI and run specific tests. The complete list is
 
 # <suite name> is the directory name of the suite to run
 -s, --suite <suite name>
+
+# (Beta) run multiple suites sequentially (comma-separated list of suite names)
+-S, --suites <suite1,suite2,...>
+
+# (Beta) run all discovered suites sequentially
+-A, --all-suites
 
 # <endpoint titles> is string of titles but where any spaces must be replaced by dashes, e.g. "Getting Started" becomes "Getting-Started" (or "getting-started" as it's case insensitive). To test multiple endpoints, separate them with a "+", e.g. "Home+Getting-Started"
 -e, --endpoint-titles <endpoint titles> 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "visreg-test",
-	"version": "6.3.0",
+	"version": "6.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "visreg-test",
-			"version": "6.3.0",
+			"version": "6.4.0",
 			"hasInstallScript": true,
 			"license": "LGPL-3.0-only",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "visreg-test",
-	"version": "6.3.0",
+	"version": "6.4.0",
 	"description": "A visual regression testing solution that offers an easy setup with simple yet powerful customisation options, wrapped up in a convenient CLI runner to make assessing and accepting/rejecting diffs a breeze.",
 	"main": "dist/run-test.js",
 	"types": "dist/types.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,12 +2,19 @@ import { Command } from 'commander';
 import { CliProgramChoices, ProgramChoices, TestTypeSlug, VisregViewport } from './types';
 import { createScaffold, parseViewport } from './utils';
 
+export type CliProgramChoicesExtended = CliProgramChoices & {
+	suites?: string;
+	allSuites?: boolean;
+};
+
 export const initialCwd = process.cwd();
 
 export const program = new Command();
 
 program
 	.option('-s, --suite <char>')
+	.option('-S, --suites <char>', 'Comma-separated list of suites to run sequentially')
+	.option('-A, --all-suites', 'Run all discovered suites sequentially')
 	.option('-e, --endpoint-titles <char>')
 	.option('-v, --viewports <char>')
 	.option('-f, --full-test [specs]')
@@ -25,7 +32,7 @@ program
 program.parse();
 
 const extractProgramChoices = () => {
-	const opts: CliProgramChoices = program.opts();
+	const opts: CliProgramChoicesExtended = program.opts();
 
 	if (opts.scaffold || opts.scaffoldTs) {
 		createScaffold();
@@ -68,10 +75,17 @@ const extractProgramChoices = () => {
 	
 	const targetEndpointTitles = opts.endpointTitles
 		? opts.endpointTitles.split('+')
-		: [];	
+		: [];
+
+	// Parse multi-suite options
+	const suites = opts.suites
+		? opts.suites.split(',').map(s => s.trim()).filter(s => s.length > 0)
+		: undefined;
 		
     const args: ProgramChoices = {
 		suite: opts?.suite,
+		suites,
+		allSuites: opts?.allSuites,
 		targetEndpointTitles,
         targetViewports,
 		testType: (testType as TestTypeSlug),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { CliProgramChoices, ProgramChoices, TestTypeSlug, VisregViewport } from './types';
 import { createScaffold, parseViewport } from './utils';
 
@@ -13,8 +13,8 @@ export const program = new Command();
 
 program
 	.option('-s, --suite <char>')
-	.option('-S, --suites <char>', 'Comma-separated list of suites to run sequentially')
-	.option('-A, --all-suites', 'Run all discovered suites sequentially')
+	.option('-S, --suites <char>', '(Beta) Comma-separated list of suites to run sequentially')
+	.option('-A, --all-suites', '(Beta) Run all discovered suites sequentially')
 	.option('-e, --endpoint-titles <char>')
 	.option('-v, --viewports <char>')
 	.option('-f, --full-test [specs]')
@@ -27,7 +27,9 @@ program
 	.option('-sc, --scaffold')
 	.option('-sct, --scaffold-ts')
 	.option('-ss, --server-start')
-	.option('-c, --containerized') // This one is used internally, not exposed to the user
+	.option('-r, --run-container', 'Run tests in a Docker container')
+	.option('-b, --build-container', 'Force-(re)build the Docker container')
+	.addOption(new Option('-c, --containerized').hideHelp())
 
 program.parse();
 

--- a/src/container-config/Dockerfile
+++ b/src/container-config/Dockerfile
@@ -4,10 +4,8 @@ FROM cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.
 # Set the working directory in the container to /app
 WORKDIR /app
 
-# Remove stale Chrome/Edge repo sources (browsers are already in the base image)
-# to prevent GPG key errors during apt-get update, then install curl and jq
-RUN rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/microsoft-edge*.list \
-    && apt-get update && apt-get install -y curl jq
+# Install curl and jq
+RUN apt-get update && apt-get install -y curl jq
 
 # Make port 3000 available outside the container (express server)
 EXPOSE 3000

--- a/src/container-config/Dockerfile
+++ b/src/container-config/Dockerfile
@@ -4,8 +4,10 @@ FROM cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.
 # Set the working directory in the container to /app
 WORKDIR /app
 
-# Install curl and jq
-RUN apt-get update && apt-get install -y curl jq
+# Remove stale Chrome/Edge repo sources (browsers are already in the base image)
+# to prevent GPG key errors during apt-get update, then install curl and jq
+RUN rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/microsoft-edge*.list \
+    && apt-get update && apt-get install -y curl jq
 
 # Make port 3000 available outside the container (express server)
 EXPOSE 3000

--- a/src/diff-assessment-terminal.ts
+++ b/src/diff-assessment-terminal.ts
@@ -17,6 +17,11 @@ type CliAssessmentArgs = {
 	visregConfig: ConfigurationSettings;
 }
 
+export const resetTerminalAssessmentState = () => {
+	approvedFiles = [];
+	rejectedFiles = [];
+};
+
 export const assessInCLI = async (args: CliAssessmentArgs) => {
 	const { files, failed, visregConfig: config } = args;
 

--- a/src/diff-assessment-web.ts
+++ b/src/diff-assessment-web.ts
@@ -121,6 +121,13 @@ export const getSummary = () => {
 	return summary;
 }
 
+export const resetWebAssessmentState = () => {
+	diffFilesForWeb = [];
+	approvedFiles = [];
+	rejectedFiles = [];
+	failed = false;
+};
+
 export const processImageViaWeb = (diffImageFile: string, index: number, total: number, suiteSlug?: string) => {
 	programChoices.suite = suiteSlug;
 	

--- a/src/server/routes/run-test/run-test.ts
+++ b/src/server/routes/run-test/run-test.ts
@@ -1,5 +1,5 @@
 import { ProgramChoices } from '../../../types';
-import { startWebTest} from '../../../visreg';
+import { startWebTest, startWebSuiteQueue } from '../../../visreg';
 import { WebSocketServer } from 'ws';
 // import { getServer } from 'src/server';
 
@@ -32,6 +32,19 @@ wss.on('connection', (websocket: WebSocket) => {
 			};			
 
 			startWebTest(ws, progChoices);
+		}
+
+		if (data.type === 'command' && data.name === 'start-queue') {
+			terminate = false;
+			const suites: string[] = data.payload.suites;
+			const testType: string = data.payload.testType;
+			const progChoices: Partial<ProgramChoices> = {
+				testType: data.payload.testType,
+				targetEndpointTitles: data.payload.targetEndpointTitles,
+				targetViewports: data.payload.targetViewports,
+			};
+
+			startWebSuiteQueue(ws, suites, testType, progChoices);
 		}
 	};
 });

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1,10 +1,18 @@
 import { programChoices } from './cli';
+import { SuiteRunResult } from './types';
 import { getDiffingFilesFromTestResult, printColorText, cleanUp } from './utils';
 
 let approvedFiles: string[] = [];
 let rejectedFiles: string[] = [];
 let failed: boolean;
 let duration: number;
+
+export const resetSummaryState = () => {
+	approvedFiles = [];
+	rejectedFiles = [];
+	failed = false;
+	duration = 0;
+};
 
 export const summarizeTest = () => {
 	failed &&
@@ -27,8 +35,8 @@ const summarizeAssessment = () => {
 	let files = getDiffingFilesFromTestResult();
 
 	if (!files) {
-		printColorText('🎉  Visual regression passed! (No diffs found)', '32');
-		process.exit();
+		printColorText('Visual regression passed! (No diffs found)', '32');
+		return;
 	}
 		
 	printColorText(`Total diffs assessed: ${approvedFiles.length + rejectedFiles.length}`, '2');
@@ -42,16 +50,56 @@ const summarizeAssessment = () => {
 	}
 }
 
-export const summarizeResultsAndQuit = (approvedFilesArg: string[], rejectedFilesArg: string[], failedArg: boolean) => {
-    approvedFiles = approvedFilesArg;
-    rejectedFiles = rejectedFilesArg;
-    failed = failedArg;
-    
+/**
+ * Summarize results without calling process.exit(). Used in queue mode
+ * so the process can continue to the next suite.
+ */
+export const summarizeResults = (approvedFilesArg: string[], rejectedFilesArg: string[], failedArg: boolean) => {
+	approvedFiles = approvedFilesArg;
+	rejectedFiles = rejectedFilesArg;
+	failed = failedArg;
+
 	printColorText('\n\nSummary', '4');
 
 	summarizeTest();
 	summarizeAssessment();
 
 	cleanUp();
+};
+
+export const summarizeResultsAndQuit = (approvedFilesArg: string[], rejectedFilesArg: string[], failedArg: boolean) => {
+	summarizeResults(approvedFilesArg, rejectedFilesArg, failedArg);
 	process.exit();
 }
+
+/**
+ * Print a combined summary for a multi-suite queue run.
+ */
+export const summarizeSuiteQueue = (suiteResults: SuiteRunResult[]) => {
+	printColorText('\n\nQueue Summary', '4');
+	printColorText('─'.repeat(60), '2');
+
+	let totalDiffs = 0;
+	let totalFailed = 0;
+
+	for (const result of suiteResults) {
+		const status = result.failed ? '\x1b[33mpartial\x1b[0m' : '\x1b[32mpassed\x1b[0m';
+		const diffCount = result.diffs.length;
+		totalDiffs += diffCount;
+		if (result.failed) totalFailed++;
+
+		console.log(`\x1b[2mSuite: \x1b[0m${result.suite}  \x1b[2m| Status: \x1b[0m${status}  \x1b[2m| Diffs: \x1b[0m${diffCount}`);
+	}
+
+	printColorText('─'.repeat(60), '2');
+	console.log(`\x1b[2mSuites run: \x1b[0m${suiteResults.length}`);
+	console.log(`\x1b[2mTotal diffs: \x1b[0m${totalDiffs}`);
+
+	if (totalFailed > 0) {
+		console.log(`\x1b[2mSuites with errors: \x1b[0m\x1b[33m${totalFailed}\x1b[0m`);
+	}
+
+	if (totalDiffs === 0) {
+		printColorText('\nVisual regression passed across all suites! (No diffs found)', '32');
+	}
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -293,6 +293,16 @@ export type TestSettings = {
 
 export type ProgramChoices = {
 	suite?: string,
+	/**
+	 * An ordered list of suites to run sequentially in queue mode.
+	 * When set, the runner iterates through each suite and collects diffs for assessment at the end.
+	 * @example ['homepage', 'dashboard', 'settings']
+	 */
+	suites?: string[],
+	/**
+	 * When true, all discovered suites are queued for sequential execution.
+	 */
+	allSuites?: boolean,
 	targetEndpointTitles: string[] | [],
 	targetViewports: (VisregViewport | [])[],
 	fullTest?: boolean | string,
@@ -307,6 +317,18 @@ export type ProgramChoices = {
 	containerized?: boolean,
 	serverStart?: boolean,
 	webTesting?: boolean,
+}
+
+/**
+ * Represents the result of running a single suite in a multi-suite queue.
+ */
+export type SuiteRunResult = {
+	/** The suite name */
+	suite: string;
+	/** Diff files produced by this suite's test run */
+	diffs: string[];
+	/** Whether the Cypress run had failures (not just visual diffs) */
+	failed: boolean;
 }
 
 export type CliProgramChoices = ProgramChoices & {

--- a/src/visreg.ts
+++ b/src/visreg.ts
@@ -4,13 +4,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import * as readline from 'readline';
-import { ConfigurationSettings, CypressScreenshotOptions, JestMatchImageSnapshotOptions, NonOverridableSettings, ProgramChoices, RequestSettings, TestSettings, TestType, VisitSettings, VisregViewport } from './types';
+import { ConfigurationSettings, CypressScreenshotOptions, JestMatchImageSnapshotOptions, NonOverridableSettings, ProgramChoices, RequestSettings, SuiteRunResult, TestSettings, TestType, VisitSettings, VisregViewport } from './types';
 import { programChoices } from './cli';
 import { startServer } from './server';
-import { assessInWeb, processImageViaWeb } from './diff-assessment-web';
+import { assessInWeb, processImageViaWeb, resetWebAssessmentState } from './diff-assessment-web';
 import { BACKUP_DIFF_DIR, BACKUP_RECEIVED_DIR, DIFF_DIR, RECEIVED_DIR, cleanUp, createFailingEndpointTestResult, createPassingEndpointTestResult, getAllDiffingFiles, getDiffingFilesFromTestResult, getSkippedEndpoints, getSuiteDirOrFail, getSuites, getUnchangedEndpoints, hasFiles, includedInTarget, isTargettedTest, parseAgenda, parseCypressSummary, parseViewport, pathExists, printColorText, projectRoot, removeBackups, suitesDirectory } from './utils';
-import { assessInCLI } from './diff-assessment-terminal';
-import { summarizeResultsAndQuit } from './summarize';
+import { assessInCLI, resetTerminalAssessmentState } from './diff-assessment-terminal';
+import { summarizeResultsAndQuit, summarizeResults, summarizeSuiteQueue, resetSummaryState } from './summarize';
 
 type DataPackage = {
 	name: string;
@@ -45,14 +45,19 @@ export type EndpointTestResultsGroup = {
 
 const defaultBrowser = 'electron';
 const configPath = path.join(projectRoot, 'visreg.config.json');
-let visregConfig: ConfigurationSettings = {};
+
+// Store the project-level config immutably so it can be cloned for each suite run
+let projectLevelConfig: ConfigurationSettings = {};
 
 if (pathExists(configPath)) {
 	const fileContent = fs.readFileSync(configPath, 'utf-8');
 	try {
-		visregConfig = JSON.parse(fileContent);
+		projectLevelConfig = JSON.parse(fileContent);
 	} catch (e) { }
 }
+
+// Working config that gets merged with suite-level config per run. Reset from projectLevelConfig between suite runs.
+let visregConfig: ConfigurationSettings = { ...projectLevelConfig };
 
 let failed = false;
 let userTerminatedTest = false;
@@ -180,7 +185,7 @@ const startLabMode = async (programChoices: ProgramChoices) => {
 }
 
 const main = async (): Promise<void> => {
-	await selectSuite();
+	await selectSuites();
 	await selectType();
 
 	const { testType } = programChoices;
@@ -195,6 +200,13 @@ const main = async (): Promise<void> => {
 		return;
 	}
 
+	// Queue mode: run multiple suites sequentially
+	if (isQueueMode()) {
+		await runSuiteQueue();
+		return;
+	}
+
+	// Single-suite mode (original behavior)
 	if (testType === 'diffs-only') {
 		exitIfNoDIffs();
 	}
@@ -249,6 +261,106 @@ const selectSuite = async () => {
 	rl.close();
 };
 
+const isQueueMode = () => {
+	return !!(programChoices.allSuites || (programChoices.suites && programChoices.suites.length > 1));
+};
+
+/**
+ * Resolve the suite queue. Populates programChoices.suites with the list of suites to run.
+ * In single-suite mode, wraps the selected suite in an array for uniform handling.
+ */
+const selectSuites = async () => {
+	const allSuites: string[] = getSuites();
+
+	if (allSuites.length === 0) {
+		printColorText('No test suites found - see README', '31');
+		process.exit(1);
+	}
+
+	// --all-suites flag: run all discovered suites
+	if (programChoices.allSuites) {
+		programChoices.suites = allSuites;
+		return;
+	}
+
+	// --suites flag: validate provided suite names
+	if (programChoices.suites && programChoices.suites.length > 0) {
+		const invalid = programChoices.suites.filter(s => !allSuites.includes(s));
+		if (invalid.length > 0) {
+			printColorText(`Unknown suite(s): ${invalid.join(', ')}`, '31');
+			printColorText(`Available suites: ${allSuites.join(', ')}`, '2');
+			process.exit(1);
+		}
+		return;
+	}
+
+	// Fall back to single-suite selection (existing behavior)
+	await selectSuite();
+	programChoices.suites = programChoices.suite ? [programChoices.suite] : [];
+};
+
+/**
+ * Run multiple suites sequentially, accumulating diffs for assessment at the end.
+ */
+const runSuiteQueue = async (): Promise<void> => {
+	const suites = programChoices.suites || [];
+	const suiteResults: SuiteRunResult[] = [];
+
+	printColorText(`\nQueue: running ${suites.length} suite(s) sequentially\n`, '36');
+
+	for (let i = 0; i < suites.length; i++) {
+		const suite = suites[i];
+		resetForNextSuite();
+		programChoices.suite = suite;
+
+		printColorText(`\n${'─'.repeat(60)}`, '36');
+		printColorText(`Suite ${i + 1}/${suites.length}: ${suite}`, '36');
+		printColorText(`${'─'.repeat(60)}\n`, '36');
+
+		if (programChoices.testType === 'diffs-only') {
+			if (!pathExists(DIFF_DIR()) || !hasFiles(DIFF_DIR())) {
+				printColorText(`No diffs found for suite "${suite}", skipping`, '2');
+				suiteResults.push({ suite, diffs: [], failed: false });
+				continue;
+			}
+		}
+
+		const allCurrentDiffs = createTemporaryDiffList();
+		backupDiffs();
+		backupReceived();
+
+		try {
+			const testResultDiffs = await runCypressTest(allCurrentDiffs);
+			suiteResults.push({
+				suite,
+				diffs: testResultDiffs || [],
+				failed,
+			});
+		} catch (error) {
+			printColorText(`Error running suite "${suite}": ${error}`, '31');
+			suiteResults.push({ suite, diffs: [], failed: true });
+		}
+	}
+
+	// Print combined queue summary
+	summarizeSuiteQueue(suiteResults);
+
+	// Collect all diffs across suites for assessment
+	const allDiffs = suiteResults.flatMap(r => r.diffs);
+	const anyFailed = suiteResults.some(r => r.failed);
+
+	if (allDiffs.length > 0) {
+		// Set suite to the first suite with diffs for the assessment UI context
+		const firstSuiteWithDiffs = suiteResults.find(r => r.diffs.length > 0);
+		if (firstSuiteWithDiffs) {
+			programChoices.suite = firstSuiteWithDiffs.suite;
+		}
+		assessExistingDiffImages(allDiffs);
+	} else {
+		summarizeResultsAndQuit([], [], anyFailed);
+	}
+};
+
 const selectType = async () => {
 	const specifiedType = typesList.find(type => type.slug === programChoices.testType);
 	if (specifiedType) {
@@ -295,7 +407,8 @@ const prepareConfig = (diffList?: string[]) => {
 
 	pathExists(suiteConfigPath) && printColorText(`\nSuite config: ${suiteConfigPath}`, '2');
 
-	Object.assign(visregConfig, suiteConfig);
+	// Merge project config with suite config without mutating the project-level config
+	visregConfig = { ...projectLevelConfig, ...suiteConfig };
 
 	const {
 		screenshotOptions,
@@ -721,7 +834,7 @@ export const getDiffsForWeb = (suiteSlug: string, conf?: ConfigurationSettings) 
 	programChoices.testType = 'assess-existing-diffs';
 	programChoices.webTesting = true;
 
-	visregConfig = conf || visregConfig;
+	visregConfig = conf || { ...projectLevelConfig };
 
 	let files = getDiffingFilesFromTestResult();
 
@@ -747,6 +860,90 @@ const resetPreviousTest = () => {
 	endpointTestResults.unchanged = [];
 }
 
+/**
+ * More thorough reset for multi-suite queue runs.
+ * Resets all module-level state that could bleed between suite runs.
+ */
+const resetForNextSuite = () => {
+	resetPreviousTest();
+
+	// Reset working config to project-level defaults
+	visregConfig = { ...projectLevelConfig };
+
+	// Reset state in other modules
+	resetWebAssessmentState();
+	resetTerminalAssessmentState();
+	resetSummaryState();
+};
+
+/**
+ * Run a queue of suites via the web UI, streaming progress over WebSocket.
+ */
+export const startWebSuiteQueue = async (ws: WebSocket, suites: string[], testType: string, progChoices: Partial<ProgramChoices>, conf?: ConfigurationSettings) => {
+	const suiteResults: SuiteRunResult[] = [];
+
+	for (let i = 0; i < suites.length; i++) {
+		const suite = suites[i];
+		resetForNextSuite();
+
+		programChoices.suite = suite;
+		programChoices.testType = testType as any;
+		programChoices.webTesting = true;
+
+		visregConfig = conf || { ...projectLevelConfig };
+
+		if (progChoices.testType === 'targetted') {
+			const parsedViewports = progChoices.targetViewports
+				? progChoices.targetViewports?.map(vp => parseViewport(vp as VisregViewport))
+				: [];
+
+			programChoices.targetViewports = parsedViewports || [];
+			programChoices.targetEndpointTitles = progChoices.targetEndpointTitles || [];
+		}
+
+		// Notify frontend of queue progress
+		ws.send(JSON.stringify({
+			type: 'queue-progress',
+			payload: { suite, index: i, total: suites.length, status: 'running' },
+		}));
+
+		if (programChoices.testType === 'diffs-only') {
+			if (!pathExists(DIFF_DIR()) || !hasFiles(DIFF_DIR())) {
+				ws.send(JSON.stringify({
+					type: 'queue-progress',
+					payload: { suite, index: i, total: suites.length, status: 'skipped' },
+				}));
+				suiteResults.push({ suite, diffs: [], failed: false });
+				continue;
+			}
+		}
+
+		const diffList = createTemporaryDiffList();
+		backupDiffs();
+		backupReceived();
+
+		try {
+			await runWebCypressTest(ws, diffList);
+			const diffs = getDiffingFilesFromTestResult();
+			suiteResults.push({ suite, diffs, failed });
+		} catch (error) {
+			suiteResults.push({ suite, diffs: [], failed: true });
+		}
+
+		ws.send(JSON.stringify({
+			type: 'queue-progress',
+			payload: { suite, index: i, total: suites.length, status: 'complete', diffs: suiteResults[suiteResults.length - 1].diffs },
+		}));
+	}
+
+	// Send final queue summary
+	const allDiffs = suiteResults.flatMap(r => r.diffs);
+	ws.send(JSON.stringify({
+		type: 'queue-complete',
+		payload: { suiteResults, allDiffs },
+	}));
+};
+
 export const startWebTest = async (ws: WebSocket, progChoices: Partial<ProgramChoices>, conf?: ConfigurationSettings) => {
 	if (!progChoices.suite || !progChoices.testType) {
 		return;
@@ -758,7 +955,7 @@ export const startWebTest = async (ws: WebSocket, progChoices: Partial<ProgramCh
 	programChoices.testType = progChoices.testType;
 	programChoices.webTesting = true;
 
-	visregConfig = conf || visregConfig;
+	visregConfig = conf || { ...projectLevelConfig };
 
 	if (programChoices.testType === 'targetted') {
 		const parsedViewports = progChoices.targetViewports

--- a/web/src/contexts/test-context.tsx
+++ b/web/src/contexts/test-context.tsx
@@ -10,6 +10,10 @@ import { AppContext } from './app-context';
 export type TestPageData = {
     suiteConfig: TestConfig;
     imagesList: ImagesList;
+    projectInformation?: {
+        suites: string[];
+        version: string;
+    };
 };
 
 export type ProgramChoices = {
@@ -88,10 +92,17 @@ export type SummaryObject = {
 export type TestTypeSlug = 'full-test' | 'diffs-only' | 'targetted';
 export type TestStatusType = 'terminated' | 'terminating' | 'running' | 'idle' | 'done';
 
+export type QueueSuiteStatus = {
+    suite: string;
+    status: 'pending' | 'running' | 'complete' | 'skipped';
+    diffs: string[];
+};
+
 type TestContextType = {
     testStatus: TestStatusType;
     selectedTargetEndpoints: string[];
     startTest: (testType: TestTypeSlug) => Promise<void>;
+    startQueueTest: (testType: TestTypeSlug, suites: string[]) => Promise<void>;
     suiteConfig: TestConfig;
     images: ImagesList;
     addTargetEndpoint: (name: string) => void;
@@ -111,6 +122,10 @@ type TestContextType = {
     updateTerminalOutput: (output: string | React.ReactElement, color?: string) => void;
     initiateTerminationOfTest: () => void;
     history?: History;
+    isQueueMode: boolean;
+    queueSuites: QueueSuiteStatus[];
+    queueProgress: string;
+    allSuites: string[];
 };
 
 const defaultValue: TestContextType = {
@@ -131,6 +146,7 @@ const defaultValue: TestContextType = {
     selectedTargetEndpoints: [],
     selectedTargetViewports: [],
     startTest: async () => {},
+    startQueueTest: async () => {},
     addTargetEndpoint: () => {},
     addTargetViewport: () => {},
     resultsRef: { current: null },
@@ -147,6 +163,10 @@ const defaultValue: TestContextType = {
     updateTerminalOutput: () => {},
     initiateTerminationOfTest: () => {},
     history: [],
+    isQueueMode: false,
+    queueSuites: [],
+    queueProgress: '',
+    allSuites: [],
 };
 
 export const TestContext = React.createContext(defaultValue);
@@ -156,7 +176,8 @@ const ws = new WebSocket('ws://localhost:8080');
 export function TestContextWrapper(props: { children: React.ReactNode; }) {
     const { testHasBeenRunThisSession, setTestHasBeenRunThisSession } = useContext(AppContext);
     
-    const { suiteConfig, imagesList } = useLoaderData() as TestPageData;
+    const { suiteConfig, imagesList, projectInformation } = useLoaderData() as TestPageData;
+    const allSuites = projectInformation?.suites || [];
 
     const resultsRef = useRef<HTMLDivElement>(null);
     const terminalRef = useRef<HTMLDivElement>(null);
@@ -176,6 +197,9 @@ export function TestContextWrapper(props: { children: React.ReactNode; }) {
         const history = localStorage.getItem('visreg-history');
         return history ? JSON.parse(history) : [];
     });
+    const [ isQueueMode, setIsQueueMode ] = useState(false);
+    const [ queueSuites, setQueueSuites ] = useState<QueueSuiteStatus[]>([]);
+    const [ queueProgress, setQueueProgress ] = useState('');
 
     useEffect(() => {
         // Only if a test has been run this session do we want to load the most recent one into the state.
@@ -207,6 +231,28 @@ export function TestContextWrapper(props: { children: React.ReactNode; }) {
         setFailingEndpoints([]);
         setVisregSummary(undefined);        
         setTerminalViewOpen(true);
+        setIsQueueMode(false);
+        setQueueSuites([]);
+        setQueueProgress('');
+
+        const res = await fetch(`${api}/test/start-ws`, { method: 'GET' });
+
+        if (res.ok) {
+            scrollDown();
+            setRunningTest(testType);
+            setTestStatus('running');
+        }
+    };
+
+    const startQueueTest = async (testType: TestTypeSlug, suites: string[]) => {
+        setTerminalOutput([]);
+        setPassingEndpoints([]);
+        setFailingEndpoints([]);
+        setVisregSummary(undefined);
+        setTerminalViewOpen(true);
+        setIsQueueMode(true);
+        setQueueSuites(suites.map(s => ({ suite: s, status: 'pending', diffs: [] })));
+        setQueueProgress(`Queued ${suites.length} suite(s)`);
 
         const res = await fetch(`${api}/test/start-ws`, { method: 'GET' });
 
@@ -341,6 +387,7 @@ export function TestContextWrapper(props: { children: React.ReactNode; }) {
             failingEndpoints,
             skippedEndpoints,
             startTest,
+            startQueueTest,
             toggleTerminalOpen,
             onFinished,
             addTargetEndpoint,
@@ -351,9 +398,13 @@ export function TestContextWrapper(props: { children: React.ReactNode; }) {
             updateTerminalOutput,
             initiateTerminationOfTest,
             history,
+            isQueueMode,
+            queueSuites,
+            queueProgress,
+            allSuites,
         }),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [failingEndpoints, passingEndpoints, skippedEndpoints, runningTest, selectedTargetEndpoints, selectedTargetViewports, suiteConfig, visregSummary, /* cypressSummaryState, */ terminalViewOpen, testStatus, terminalOutput, imagesList, history],
+        [failingEndpoints, passingEndpoints, skippedEndpoints, runningTest, selectedTargetEndpoints, selectedTargetViewports, suiteConfig, visregSummary, /* cypressSummaryState, */ terminalViewOpen, testStatus, terminalOutput, imagesList, history, isQueueMode, queueSuites, queueProgress, allSuites],
     );
 
     return (

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './app.tsx';
+import App from './App.tsx';
 import './styles/index.css';
 import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
@@ -177,19 +177,20 @@ const router = createBrowserRouter([
 							},
 						},
 					},
-					{
-						path: "/suite/:suiteSlug/run-test",
-						element: (
-							<TestContextWrapper>
-								<TestPage />
-							</TestContextWrapper>
-						),
-						loader: async ({ params }) => {
-							const imagesList = await getSuiteImagesList(params.suiteSlug);
-							const suiteConfig = await getSuiteConfig(params.suiteSlug);
+				{
+					path: "/suite/:suiteSlug/run-test",
+					element: (
+						<TestContextWrapper>
+							<TestPage />
+						</TestContextWrapper>
+					),
+					loader: async ({ params }) => {
+						const imagesList = await getSuiteImagesList(params.suiteSlug);
+						const suiteConfig = await getSuiteConfig(params.suiteSlug);
+						const projectInformation = await getProjectInformation();
 
-							return {imagesList, suiteConfig };
-						},
+						return {imagesList, suiteConfig, projectInformation };
+					},
 						handle: {
 							crumb: ({ suiteSlug }: { suiteSlug: string; }) => {
 								return [

--- a/web/src/pages/test-page/panel/terminal/terminal.tsx
+++ b/web/src/pages/test-page/panel/terminal/terminal.tsx
@@ -4,21 +4,31 @@ import { TestTypeSlug, TestContext } from '../../../../contexts/test-context';
 import { terminalStyles } from '../../../../styles/terminal-style';
 
 export type WebSocketData = {
-    type: 'command' | 'data' | 'error' | 'text';
-    name: 'start-test' | 'summary' | 'terminate';
+    type: 'command' | 'data' | 'error' | 'text' | 'queue-progress' | 'queue-complete';
+    name: 'start-test' | 'start-queue' | 'summary' | 'terminate';
     payload: string | object;
 };
 
 
 export type WebSocketCommand = WebSocketData & {
     type: 'command';
-    name: 'start-test' | 'terminate';
+    name: 'start-test' | 'start-queue' | 'terminate';
 };
 
 type WebSocketStartTest = WebSocketCommand & {
     name: 'start-test';
     payload: {
         suiteSlug: string;
+        testType: TestTypeSlug;
+        targetEndpointTitles?: string[];
+        targetViewports?: (string | number[])[];
+    };
+};
+
+type WebSocketStartQueue = WebSocketCommand & {
+    name: 'start-queue';
+    payload: {
+        suites: string[];
         testType: TestTypeSlug;
         targetEndpointTitles?: string[];
         targetViewports?: (string | number[])[];
@@ -36,6 +46,8 @@ const Terminal = () => {
         selectedTargetViewports,
         terminalOutput,
         updateTerminalOutput,
+        isQueueMode,
+        queueSuites,
     } = useContext(TestContext);
 
     
@@ -52,20 +64,39 @@ const Terminal = () => {
         const ws = new WebSocket('ws://localhost:8080');
 
         if (testStatus === 'running') {
-            const data: WebSocketStartTest = {
-                type: 'command',
-                name: 'start-test',
-                payload: {
-                    suiteSlug: suiteConfig.suiteSlug,
-                    testType: runningTest!,
-                    targetEndpointTitles: selectedTargetEndpoints,
-                    targetViewports: selectedTargetViewports,
-                },
-            };
-            
-            ws.onopen = () => {
-                ws.send(JSON.stringify(data));
-            };
+            if (isQueueMode && queueSuites.length > 0) {
+                // Queue mode: send start-queue command with all suite names
+                const data: WebSocketStartQueue = {
+                    type: 'command',
+                    name: 'start-queue',
+                    payload: {
+                        suites: queueSuites.map(s => s.suite),
+                        testType: runningTest!,
+                        targetEndpointTitles: selectedTargetEndpoints,
+                        targetViewports: selectedTargetViewports,
+                    },
+                };
+
+                ws.onopen = () => {
+                    ws.send(JSON.stringify(data));
+                };
+            } else {
+                // Single suite mode
+                const data: WebSocketStartTest = {
+                    type: 'command',
+                    name: 'start-test',
+                    payload: {
+                        suiteSlug: suiteConfig.suiteSlug,
+                        testType: runningTest!,
+                        targetEndpointTitles: selectedTargetEndpoints,
+                        targetViewports: selectedTargetViewports,
+                    },
+                };
+                
+                ws.onopen = () => {
+                    ws.send(JSON.stringify(data));
+                };
+            }
         }
 
         ws.onmessage = (event) => {
@@ -73,10 +104,31 @@ const Terminal = () => {
 
             if (data.type === 'data') {
                 if (data.payload.name === 'visreg-summary') {
-                    ws.close();
+                    if (!isQueueMode) {
+                        ws.close();
+                    }
                     onFinished(data.payload);
                     return;
                 }
+                return;
+            }
+
+            if (data.type === 'queue-progress') {
+                const { suite, index, total, status } = data.payload;
+                updateTerminalOutput(
+                    `\n--- Suite ${index + 1}/${total}: ${suite} [${status}] ---\n`,
+                    '#4FC3F7'
+                );
+                return;
+            }
+
+            if (data.type === 'queue-complete') {
+                const { suiteResults, allDiffs } = data.payload;
+                updateTerminalOutput(
+                    `\n--- Queue complete: ${suiteResults.length} suite(s), ${allDiffs.length} total diff(s) ---\n`,
+                    '#81C784'
+                );
+                ws.close();
                 return;
             }
 

--- a/web/src/pages/test-page/selection/suite-queue-selector.tsx
+++ b/web/src/pages/test-page/selection/suite-queue-selector.tsx
@@ -1,0 +1,140 @@
+import { Card, CardActionArea, CardContent, Checkbox, FormControlLabel, FormGroup, Typography } from '@mui/material';
+import x from '@stylexjs/stylex';
+import { useContext, useState } from 'react';
+import { TestContext, TestTypeSlug } from '../../../contexts/test-context';
+
+const s = x.create({
+    cardSection: {
+        width: 'min-content',
+        minWidth: '300px',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        gap: '1rem',
+        height: 'min-content',
+    },
+    cardContent: {
+        paddingBottom: 0,
+    },
+    suiteList: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.25rem',
+        marginTop: '0.5rem',
+        maxHeight: '300px',
+        overflowY: 'auto',
+    },
+});
+
+type SuiteQueueSelectorProps = {
+    testType: TestTypeSlug;
+};
+
+export const SuiteQueueSelector = ({ testType }: SuiteQueueSelectorProps) => {
+    const {
+        testStatus,
+        startQueueTest,
+        suiteConfig,
+        allSuites,
+    } = useContext(TestContext);
+
+    const otherSuites = allSuites.filter(s => s !== suiteConfig.suiteSlug);
+    const [selectedSuites, setSelectedSuites] = useState<string[]>([]);
+
+    if (otherSuites.length === 0) {
+        return null;
+    }
+
+    const isDisabled = testStatus === 'running' || testStatus === 'terminating';
+
+    const toggleSuite = (suite: string) => {
+        setSelectedSuites(prev =>
+            prev.includes(suite)
+                ? prev.filter(s => s !== suite)
+                : [...prev, suite]
+        );
+    };
+
+    const toggleAll = () => {
+        if (selectedSuites.length === otherSuites.length) {
+            setSelectedSuites([]);
+        } else {
+            setSelectedSuites([...otherSuites]);
+        }
+    };
+
+    const queuedSuites = [suiteConfig.suiteSlug, ...selectedSuites];
+    const canRun = selectedSuites.length > 0;
+
+    return (
+        <Card
+            elevation={isDisabled ? 0 : 3}
+            sx={{ borderRadius: '1rem' }}
+            {...x.props(s.cardSection)}
+        >
+            <CardContent {...x.props(s.cardContent)}>
+                <Typography variant='h5' color={isDisabled ? 'text.disabled' : 'text.primary'} mb={1}>
+                    Queue
+                </Typography>
+                <Typography variant='body1' color={isDisabled ? 'text.disabled' : 'text.primary'} mb={1}>
+                    Run a {testType} test across multiple suites sequentially
+                </Typography>
+
+                <FormGroup {...x.props(s.suiteList)}>
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={true}
+                                disabled={true}
+                            />
+                        }
+                        label={
+                            <Typography variant='body2' color='text.secondary'>
+                                {suiteConfig.suiteSlug} (current)
+                            </Typography>
+                        }
+                    />
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={selectedSuites.length === otherSuites.length}
+                                indeterminate={selectedSuites.length > 0 && selectedSuites.length < otherSuites.length}
+                                onChange={toggleAll}
+                                disabled={isDisabled}
+                            />
+                        }
+                        label={
+                            <Typography variant='body2' fontWeight='bold'>
+                                Select all
+                            </Typography>
+                        }
+                    />
+                    {otherSuites.map(suite => (
+                        <FormControlLabel
+                            key={suite}
+                            control={
+                                <Checkbox
+                                    checked={selectedSuites.includes(suite)}
+                                    onChange={() => toggleSuite(suite)}
+                                    disabled={isDisabled}
+                                    size='small'
+                                />
+                            }
+                            label={<Typography variant='body2'>{suite}</Typography>}
+                        />
+                    ))}
+                </FormGroup>
+            </CardContent>
+
+            <CardActionArea
+                sx={{ padding: '1rem', display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+                disabled={isDisabled || !canRun}
+                onClick={() => startQueueTest(testType, queuedSuites)}
+            >
+                <Typography variant='h6' color={isDisabled || !canRun ? 'text.disabled' : 'primary'}>
+                    Run {queuedSuites.length} suite{queuedSuites.length > 1 ? 's' : ''}
+                </Typography>
+            </CardActionArea>
+        </Card>
+    );
+};

--- a/web/src/pages/test-page/selection/test-selection.tsx
+++ b/web/src/pages/test-page/selection/test-selection.tsx
@@ -3,6 +3,8 @@ import x from '@stylexjs/stylex';
 import { TargettedTestSettings } from './targetted-test-settings/targetted-test-settings';
 import { useContext } from 'react';
 import { TestContext } from '../../../contexts/test-context';
+import { SuiteQueueSelector } from './suite-queue-selector';
+import { Typography } from '@mui/material';
 
 const s = x.create({
     cardsContainer: {
@@ -12,12 +14,18 @@ const s = x.create({
         justifyContent: 'center',
         minWidth: '320px',
     },
+    sectionLabel: {
+        width: '100%',
+        textAlign: 'center',
+        marginTop: '1.5rem',
+    },
 });
 
 export const TestSelection = () => {
-    const { images } = useContext(TestContext);
+    const { images, allSuites } = useContext(TestContext);
 
     const diffsCount = images.diffList.length;
+    const hasMultipleSuites = allSuites.length > 1;
 
     return (
         <div {...x.props(s.cardsContainer)}>
@@ -42,6 +50,18 @@ export const TestSelection = () => {
             >
                 <TargettedTestSettings />
             </TestOption>
+
+            {hasMultipleSuites && (
+                <>
+                    <div {...x.props(s.sectionLabel)}>
+                        <Typography variant='h6' color='text.secondary'>
+                            Multi-suite queue
+                        </Typography>
+                    </div>
+                    <SuiteQueueSelector testType='full-test' />
+                    <SuiteQueueSelector testType='diffs-only' />
+                </>
+            )}
         </div>   
     )
 }


### PR DESCRIPTION
Add the ability to run multiple test suites sequentially in a single session, with all diffs assessed together at the end. This works in both the CLI and web UI.

CLI:
- New flags: -S/--suites (comma-separated) and -A/--all-suites
- Suites run sequentially with per-suite progress and a combined queue summary table at the end
- Single-suite mode (-s) is unchanged and fully backwards compatible

Web UI:
- New 'Multi-suite queue' section on the test page with checkbox-based suite selection for both full-test and diffs-only modes
- WebSocket start-queue command streams per-suite progress to the terminal panel
- Queue feature only appears when multiple suites are discovered

Backend fixes:
- Fix visregConfig mutation bug: prepareConfig() used Object.assign() which permanently mutated the shared project-level config object. Now stores project config immutably and creates fresh merges per run.
- Add state reset functions (resetWebAssessmentState, resetTerminalAssessmentState, resetSummaryState) to prevent module-level state from bleeding between suite runs
- Extract non-exiting summarizeResults() from summarizeResultsAndQuit() so queue mode can continue after summarizing each suite

Misc:
- Fix case-sensitivity bug in web/src/main.tsx (app.tsx -> App.tsx)
- Bump version to 6.4.0